### PR TITLE
Update LuaCompat.h

### DIFF
--- a/LuaIntf/LuaCompat.h
+++ b/LuaIntf/LuaCompat.h
@@ -64,7 +64,7 @@
 
 //---------------------------------------------------------------------------
 
-#if !LUAINTF_BUILD_LUA_CXX
+#if LUAINTF_BUILD_LUA_CXX
 extern "C"
 {
 #endif
@@ -72,7 +72,7 @@ extern "C"
 #include "lualib.h"
 #include "lauxlib.h"
 
-#if !LUAINTF_BUILD_LUA_CXX
+#if LUAINTF_BUILD_LUA_CXX
 }
 #endif
 


### PR DESCRIPTION
Lua need 'extern "C" ' in C++

```
/home/theaifam5/Documents/CLion Projects/TiC/src/ScriptEngine/Lua/LuaState.h:272: undefined reference to `luaL_newstate()'
/home/theaifam5/Documents/CLion Projects/TiC/src/ScriptEngine/Lua/LuaRef.h:762: undefined reference to `lua_rawset(lua_State*, int)'
/home/theaifam5/Documents/CLion Projects/TiC/src/ScriptEngine/Lua/LuaRef.h:763: undefined reference to `lua_settop(lua_State*, int)'
/home/theaifam5/Documents/CLion Projects/TiC/src/ScriptEngine/Lua/Impl/LuaType.h:213: undefined reference to `lua_pushstring(lua_State*, char const*)'
/home/theaifam5/Documents/CLion Projects/TiC/src/ScriptEngine/Lua/Impl/LuaType.h:215: undefined reference to `lua_pushnil(lua_State*)'
[...] MORE MORE AND MORE
```
