### PR TITLE
Fix addFunction for const reference types

### DIFF
--- a/LuaIntf/impl/CppArg.h
+++ b/LuaIntf/impl/CppArg.h
@@ -102,6 +102,7 @@ struct CppArgTraits
 {
     using Type = T;
     using ValueType = typename LuaType<T>::ValueType;
+    using DecayedValueType = typename std::decay<ValueType>::type;
     using HolderType = CppArgHolder<ValueType>;
     static constexpr bool IsInput = true;
     static constexpr bool IsOutput = false;
@@ -171,6 +172,7 @@ struct CppArgTraits <lua_State*>
 {
     using Type = lua_State*;
     using ValueType = lua_State*;
+    using DecayedValueType = ValueType;
     using HolderType = CppArgHolder<ValueType>;
     static constexpr bool IsInput = false;
     static constexpr bool IsOutput = false;
@@ -183,6 +185,7 @@ struct CppArgTraits <LuaState>
 {
     using Type = LuaState;
     using ValueType = LuaState;
+    using DecayedValueType = ValueType;
     using HolderType = CppArgHolder<ValueType>;
     static constexpr bool IsInput = false;
     static constexpr bool IsOutput = false;
@@ -219,7 +222,7 @@ struct CppArgInput <Traits, true, true, false>
 {
     static int get(lua_State* L, int index, typename Traits::HolderType& r)
     {
-        using DefaultType = typename std::decay<typename Traits::ValueType>::type;
+        using DefaultType = typename Traits::DecayedValueType;
         r.hold(LuaType<typename Traits::Type>::opt(L, index, DefaultType()));
         return 1;
     }
@@ -263,7 +266,7 @@ struct CppArgOutput;
 template <typename Traits>
 struct CppArgOutput <Traits, false>
 {
-    static int push(lua_State*, const typename Traits::ValueType&)
+    static int push(lua_State*, const typename Traits::DecayedValueType&)
     {
         return 0;
     }
@@ -272,7 +275,7 @@ struct CppArgOutput <Traits, false>
 template <typename Traits>
 struct CppArgOutput <Traits, true>
 {
-    static int push(lua_State* L, const typename Traits::ValueType& v)
+    static int push(lua_State* L, const typename Traits::DecayedValueType& v)
     {
         LuaType<typename Traits::Type>::push(L, v);
         return 1;


### PR DESCRIPTION
Sometime after my original change to introduce wrapped (holder) types for argument passing, the code no longer allowed me to use functions which had const reference type arguments. I believe the issue is that the push methods on CppArgOutput took 'const typename Traits::ValueType&' arguments, and this was deriving to 'const const Type&&' for const reference arguments.
