### PR TITLE
Make it possible to bind to const float, etc

### DIFF
--- a/LuaIntf/impl/LuaType.h
+++ b/LuaIntf/impl/LuaType.h
@@ -371,6 +371,7 @@ struct LuaType <T&, typename std::enable_if<std::is_enum<T>::value>::type>
 #define LUA_USING_VALUE_TYPE_EXT(T, V) \
     template <> struct LuaType <T> : LuaValueType <T, V> {}; \
     template <> struct LuaType <T&> : LuaValueType <T, V> {}; \
+    template <> struct LuaType <T const> : LuaValueType <T, V> {}; \
     template <> struct LuaType <T const&> : LuaValueType <T, V> {};
 
 #define LUA_USING_VALUE_TYPE(T) \


### PR DESCRIPTION
This was removed this when you were cleaning up after merging my original change. I don't know if you had a good reason, but this does enable some other code to compile like:

class bar {
  const float foo() const;
}
addProperty(foo, &class::bar)

So I'd like to keep it if you don't think it does any harm.
