### PR TITLE
Make CppObject base class more configurable

### DIFF
--- a/LuaIntf/impl/CppObject.h
+++ b/LuaIntf/impl/CppObject.h
@@ -117,7 +117,6 @@ protected:
     explicit CppObject(void* ptr)
         : m_ptr(ptr)
     {
-        assert(ptr != nullptr);
     }
 
     template <typename T>
@@ -153,7 +152,7 @@ public:
     /**
      * The object pointer
      */
-    void* ptr() const
+    virtual void* ptr() const
     {
         return m_ptr;
     }


### PR DESCRIPTION
Update CppObject so that users can define custom CppObjectSharedPtr specializations that do not dereference the pointer on construction.
