### PR TITLE
don't break if error message contains a %

### DIFF
--- a/LuaIntf/LuaRef.h
+++ b/LuaIntf/LuaRef.h
@@ -1219,7 +1219,7 @@ private:
             obj->~T();
             return 0;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 

--- a/LuaIntf/impl/CppBindClass.h
+++ b/LuaIntf/impl/CppBindClass.h
@@ -41,7 +41,7 @@ struct CppBindClassConstructor <T, T, _arg(*)(P...)>
             CppObjectValue<T>::pushToStack(L, args, false);
             return 1;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -61,7 +61,7 @@ struct CppBindClassConstructor <SP, T, _arg(*)(P...)>
             CppObjectSharedPtr<SP, T>::pushToStack(L, obj, false);
             return 1;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -81,7 +81,7 @@ struct CppBindClassDestructor
             obj->~CppObject();
             return 0;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -108,7 +108,7 @@ struct CppBindClassVariableGetter
             LuaType<PV>::push(L, obj->**mp);
             return 1;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -133,7 +133,7 @@ struct CppBindClassVariableSetter
             obj->**mp = LuaType<V>::get(L, 2);
             return 0;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -171,7 +171,7 @@ struct CppBindClassMethodBase
             int n = CppInvokeClassMethod<T, IS_PROXY, FN, R, typename CppArg<P>::HolderType...>::push(L, obj, fn, args);
             return n + CppArgTupleOutput<P...>::push(L, args);
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 

--- a/LuaIntf/impl/CppBindModule.h
+++ b/LuaIntf/impl/CppBindModule.h
@@ -58,7 +58,7 @@ struct CppBindVariableGetter
             LuaType<PT>::push(L, *ptr);
             return 1;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -83,7 +83,7 @@ struct CppBindVariableSetter
             *ptr = LuaType<T>::get(L, 1);
             return 0;
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 };
@@ -124,7 +124,7 @@ struct CppBindMethodBase
             int n = CppInvokeMethod<FN, R, typename CppArg<P>::HolderType...>::push(L, fn, args);
             return n + CppArgTupleOutput<P...>::push(L, args);
         } catch (std::exception& e) {
-            return luaL_error(L, e.what());
+            return luaL_error(L, "%s", e.what());
         }
     }
 

--- a/LuaIntf/src/CppFunction.cpp
+++ b/LuaIntf/src/CppFunction.cpp
@@ -37,7 +37,7 @@ LUA_INLINE int CppFunctor::call(lua_State* L)
         CppFunctor* f = static_cast<CppFunctor*>(lua_touserdata(L, 1));
         return f->run(L);
     } catch (std::exception& e) {
-        return luaL_error(L, e.what());
+        return luaL_error(L, "%s", e.what());
     }
 }
 
@@ -48,7 +48,7 @@ LUA_INLINE int CppFunctor::gc(lua_State* L)
         f->~CppFunctor();
         return 0;
     } catch (std::exception& e) {
-        return luaL_error(L, e.what());
+        return luaL_error(L, "%s", e.what());
     }
 }
 
@@ -58,7 +58,7 @@ LUA_INLINE int CppFunctor::callp(lua_State* L)
         CppFunctor* f = *static_cast<CppFunctor**>(lua_touserdata(L, 1));
         return f->run(L);
     } catch (std::exception& e) {
-        return luaL_error(L, e.what());
+        return luaL_error(L, "%s", e.what());
     }
 }
 
@@ -69,7 +69,7 @@ LUA_INLINE int CppFunctor::gcp(lua_State* L)
         delete f;
         return 0;
     } catch (std::exception& e) {
-        return luaL_error(L, e.what());
+        return luaL_error(L, "%s", e.what());
     }
 }
 


### PR DESCRIPTION
Passing a user-generated string to printf-like function is dangerous : if it have a % into, it will fail (or crash)