### PR TITLE
Avoid assignment from larger to smaller type in x64

### DIFF
--- a/LuaIntf/LuaState.h
+++ b/LuaIntf/LuaState.h
@@ -130,8 +130,8 @@ namespace Lua
     {
         luaL_checktype(L, index, LUA_TTABLE);
         LIST list;
-        int n = luaL_len(L, index);
-        for (int i = 1; i <= n; i++) {
+        auto n = luaL_len(L, index);
+        for (auto i = 1; i <= n; i++) {
             lua_rawgeti(L, index, i);
             list.push_back(pop<typename LIST::value_type>(L));
         }


### PR DESCRIPTION
In x64 mode Lua compiles with `lua_Integer` type being defined as `long long`. When I use macro `LUA_USING_LIST_TYPE(std::vector)` and then register any methods that accept `std::vectors`, I get a a warning by Visual Studio about possible data loss, with a huge listing of where it happens. Turns out the reason was the place I fixed here. Making `n` and `i` of `lua_Integer` seems like a sensible solution here, especially because the code expects them to be it.