### PR TITLE
feat: basic 5.4 support

### DIFF
--- a/LuaIntf/LuaState.h
+++ b/LuaIntf/LuaState.h
@@ -300,8 +300,13 @@ public:
     void setAllocFunc(lua_Alloc func, void* userdata = nullptr) const
         { lua_setallocf(L, func, userdata);}
 
+#if LUA_VERSION_NUM <= 503
     const lua_Number* version() const
         { return lua_version(L); }
+#else
+    const lua_Number version() const
+        { return lua_version(L); }
+#endif
 
     void checkVersion() const
         { luaL_checkversion(L); }
@@ -723,9 +728,12 @@ public:
 #if LUA_VERSION_NUM == 501
     int resume(int num_args) const
         { return lua_resume(L, num_args); }
+#elif LUA_VERSION_NUM <= 503
+    int resume(int num_args) const
+        { return lua_resume(L, num_args); }
 #else
-    int resume(int num_args, lua_State* from = nullptr) const
-        { return lua_resume(L, from, num_args); }
+    int resume(int num_args, int* num_results, lua_State* from = nullptr) const
+        { return lua_resume(L, from, num_args, num_results); }
 #endif
 
     int status() const


### PR DESCRIPTION
I have started working with 5.4 and ran into some compilation issues due to the API changes (see [here](https://www.lua.org/manual/5.4/manual.html#8.3)).

This PR adds basic support by resolving the `lua_resume` and `lua_version` API changes but doesn't update any of the `lua_newuserdata`, `lua_setuservalue` or `lua_getuservalue` changes.